### PR TITLE
Create `lib.rs,` allowing the engine to be used by other crates as a library

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use common::game::*;
+pub use common::*;
 
 pub fn new_game(size: usize, opt: Options) -> Result<Box<dyn Game>, NewGameError> {
     Ok(match size {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-mod game;
 mod tei;
 
 use std::{
@@ -7,7 +6,7 @@ use std::{
     time::Instant,
 };
 
-use crate::game::new_game;
+use cataklysm::new_game;
 use common::game::*;
 
 use tokio::runtime::Builder;

--- a/src/tei.rs
+++ b/src/tei.rs
@@ -1,6 +1,6 @@
 use std::{pin::Pin, thread::spawn};
 
-use crate::game::new_game;
+use cataklysm::new_game;
 use common::{game::*, pair::Pair};
 
 use tokio::{


### PR DESCRIPTION
Users specify it in their `Cargo.toml` like so:
```toml
cataklysm = { git = "https://github.com/alion02/cataklysm" }
```
This is what using it as a library looks like (`Position<S>` is a type from Tiltak):

```rust
use std::time::Instant;

use cataklysm::{game::Options, new_game};
use pgn_traits::PgnPosition;
use tiltak::position::Position;

pub fn cataklysm_search<const S: usize>(position: Position<S>) {
    let mut options: Options = Options {
        half_komi: position.komi().half_komi() as i32,
        ..Options::default(S).unwrap()
    };

    options.params.tt_size = 1 << 26; // Set the transposition table size to 2 GiB

    let mut game = new_game(S, options).unwrap();
    game.set_position(&position.to_fen()).unwrap();

    let start_time = Instant::now();

    for depth in 1..=10 {
        let (eval, mv) = game.search(depth).unwrap();
        let nodes = game.nodes();
        let pv = game.pv();
        println!("Komi: {}, tps: {}", position.komi(), position.to_fen());
        println!(
            "Depth: {}, nodes: {}, eval: {}, move: {}, pv: {}, {:.2}s elapsed",
            depth,
            nodes,
            eval,
            mv,
            pv,
            start_time.elapsed().as_secs_f64()
        );
    }
    println!();
}

```